### PR TITLE
Fix/karpenter node role sed

### DIFF
--- a/archive_docs/deployment_instructions_details.en.md
+++ b/archive_docs/deployment_instructions_details.en.md
@@ -179,7 +179,7 @@ Get the KarpenterInstanceNodeRole in Section 2 and run the following command to 
 
 ```shell
 KarpenterInstanceNodeRole="Comfyui-Cluster-ComfyuiClusterkarpenternoderoleE627-juyEInBqoNtU" # Modify the role to your own.
-sed -i "s/role: KarpenterInstanceNodeRole.*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1.yaml
+sed -i "s/role: .*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1.yaml
 kubectl apply -f comfyui-on-eks/manifests/Karpenter/karpenter_v1.yaml
 ```
 
@@ -187,7 +187,7 @@ kubectl apply -f comfyui-on-eks/manifests/Karpenter/karpenter_v1.yaml
 
 ```shell
 KarpenterInstanceNodeRole="Comfyui-Cluster-ComfyuiClusterkarpenternoderoleE627-juyEInBqoNtU" # Modify the role to your own.
-sed -i '' "s/role: KarpenterInstanceNodeRole.*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1.yaml
+sed -i '' "s/role: .*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1.yaml
 kubectl apply -f comfyui-on-eks/manifests/Karpenter/karpenter_v1.yaml
 ```
 

--- a/archive_docs/deployment_instructions_details.zh.md
+++ b/archive_docs/deployment_instructions_details.zh.md
@@ -190,7 +190,7 @@ docker image inspect $image_name|grep Architecture
 
 ```shell
 KarpenterInstanceNodeRole="Comfyui-Cluster-ComfyuiClusterkarpenternoderoleE627-juyEInBqoNtU" # Modify the role to your own.
-sed -i "s/role: KarpenterInstanceNodeRole.*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1beta1.yaml
+sed -i "s/role: .*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1beta1.yaml
 kubectl apply -f comfyui-on-eks/manifests/Karpenter/karpenter_v1beta1.yaml
 ```
 
@@ -198,7 +198,7 @@ kubectl apply -f comfyui-on-eks/manifests/Karpenter/karpenter_v1beta1.yaml
 
 ```shell
 KarpenterInstanceNodeRole="Comfyui-Cluster-ComfyuiClusterkarpenternoderoleE627-juyEInBqoNtU" # Modify the role to your own.
-sed -i '' "s/role: KarpenterInstanceNodeRole.*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1beta1.yaml
+sed -i '' "s/role: .*/role: $KarpenterInstanceNodeRole/g" comfyui-on-eks/manifests/Karpenter/karpenter_v1beta1.yaml
 kubectl apply -f comfyui-on-eks/manifests/Karpenter/karpenter_v1beta1.yaml
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixes the manual deployment instruction step for deploying Karpenter.

The existing `sed` command does not properly match against the mocked `role:` line in [karpenter_v1.yaml](https://github.com/aws-samples/comfyui-on-eks/blob/5ccdffd9653d00d007f1703a886bb2c48ae6c7ae/manifests/Karpenter/karpenter_v1.yaml#L44C3-L44C63)