### PR TITLE
fix(#28): write ComfyUI video output to local scratch + S3 sync sidecar

### DIFF
--- a/auto_deploy/deploy_infra.sh
+++ b/auto_deploy/deploy_infra.sh
@@ -272,6 +272,26 @@ deploy_pod_identity() {
         }]
     }"
 
+    # S3 write for the video-s3-sync sidecar (issue #28): the pod writes video output to a
+    # local scratch dir (Mountpoint S3 can't do ffmpeg's .mp4 seeks) and syncs it here.
+    # Scoped to the outputs bucket video/ prefix only.
+    aws iam put-role-policy --role-name $BEDROCK_ROLE_NAME --policy-name OutputsVideoS3Write --policy-document "{
+        \"Version\": \"2012-10-17\",
+        \"Statement\": [
+            {
+                \"Effect\": \"Allow\",
+                \"Action\": [\"s3:PutObject\", \"s3:AbortMultipartUpload\"],
+                \"Resource\": \"arn:aws:s3:::comfyui-outputs-${ACCOUNT_ID}-${AWS_DEFAULT_REGION}/video/*\"
+            },
+            {
+                \"Effect\": \"Allow\",
+                \"Action\": [\"s3:ListBucket\"],
+                \"Resource\": \"arn:aws:s3:::comfyui-outputs-${ACCOUNT_ID}-${AWS_DEFAULT_REGION}\",
+                \"Condition\": { \"StringLike\": { \"s3:prefix\": [\"video/*\"] } }
+            }
+        ]
+    }"
+
     # Create service account
     kubectl create serviceaccount comfyui-sa -n default 2>/dev/null || true
 

--- a/manifests/ComfyUI/comfyui_deployment.yaml
+++ b/manifests/ComfyUI/comfyui_deployment.yaml
@@ -27,6 +27,12 @@ spec:
       - name: comfyui-outputs
         persistentVolumeClaim:
           claimName: comfyui-outputs-pvc # Need to apply sd-outputs-s3.yaml first
+      # Local scratch for video output. Mountpoint S3 (the outputs mount) only supports
+      # sequential writes to new objects; ffmpeg .mp4 muxing seeks/renames and fails with
+      # [Errno 22] (issue #28). ffmpeg writes here (full POSIX), the video-s3-sync sidecar
+      # copies finished files to the outputs bucket under video/.
+      - name: comfyui-video-scratch
+        emptyDir: {}
       containers:
       - name: comfyui
         image: ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/comfyui-images:latest
@@ -44,8 +50,35 @@ spec:
           name: comfyui-inputs
         - mountPath: /app/ComfyUI/output
           name: comfyui-outputs
+        - mountPath: /app/ComfyUI/output/video
+          name: comfyui-video-scratch
         resources:
           requests:
             nvidia.com/gpu: 1
           limits:
             nvidia.com/gpu: 1
+      # Sidecar: copy finished videos from the local scratch dir to the outputs bucket
+      # under video/. Uses the comfyui-sa Pod Identity role (needs s3:PutObject/ListBucket
+      # on the outputs bucket video/ prefix — added in deploy_infra.sh deploy_pod_identity).
+      - name: video-s3-sync
+        image: public.ecr.aws/aws-cli/aws-cli:latest
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            while true; do
+              aws s3 sync /video "s3://comfyui-outputs-ACCOUNT_ID-REGION/video/" --region REGION --no-progress --only-show-errors || true
+              sleep 30
+            done
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - mountPath: /video
+          name: comfyui-video-scratch
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi


### PR DESCRIPTION
Mountpoint for S3 (the outputs mount) only supports sequential writes to new objects, so ffmpeg .mp4 muxing fails with [Errno 22] on /output/video. Mount /app/ComfyUI/output/video as a node-local emptyDir (full POSIX) so video nodes work, keep images writing straight to S3, and add a video-s3-sync sidecar that copies finished videos to the outputs bucket under video/. Grant the comfyui-sa Pod Identity role least-privilege s3:PutObject/ListBucket scoped to that prefix.

Resolves aws-samples/comfyui-on-eks#28

*Issue #, if available:*
Problem: "Save video" fails with [Errno 22] Invalid argument writing .mp4 to /output/video (#28). Root cause: /output is a Mountpoint-for-S3 mount, which only supports sequential writes to new objects; ffmpeg mp4 muxing seeks back / write-renames → EINVAL. Fix: mount /app/ComfyUI/output/video as a node-local emptyDir (full POSIX, so muxing works); images still write straight to S3; add a video-s3-sync sidecar that copies finished videos to the outputs bucket video/ prefix, backed by a least-privilege s3:PutObject/ListBucket grant on the comfyui-sa Pod Identity role. Tests: N/A automated. Manual: run a video workflow, confirm the mp4 saves and appears under s3://comfyui-outputs-<acct>-<region>/video/. No UI change → no screenshots.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
