### PR TITLE
fix(#27): raise ALB idle timeout to keep ComfyUI websocket alive

### DIFF
--- a/manifests/ComfyUI/comfyui_service.yaml
+++ b/manifests/ComfyUI/comfyui_service.yaml
@@ -27,6 +27,10 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internal
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=300
+    # Raise the ALB idle timeout (default 60s) so the ComfyUI progress WebSocket is not
+    # torn down between generations, which surfaced as "Reconnecting/Reconnected" every
+    # ~60s (issue #27). 4000s is the ALB maximum.
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=4000
     alb.ingress.kubernetes.io/tags: Project=comfyui-on-eks
 spec:
   ingressClassName: alb


### PR DESCRIPTION
The ComfyUI progress WebSocket runs through the internal ALB (comfyui-ingress), which had no idle-timeout annotation and so used the ALB default of 60s. When a ws sat idle for 60s between generations the ALB tore it down, surfacing as 'Reconnecting'/'Reconnected' roughly every minute in the UI (issue #27).

Add alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=4000 so the websocket is not dropped between jobs.

Resolves aws-samples/comfyui-on-eks#27

Problem: ComfyUI shows "Reconnecting"/"Reconnected" roughly every minute during normal use (#27); CPU/memory fine, pod not restarting. Root cause: The progress WebSocket runs through the internal ALB (comfyui-ingress), which had no idle-timeout annotation and used the ALB default of 60 s. An idle ws between generations gets torn down at 60 s → the client reconnects, on a ~1-minute cadence. Fix: Add alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=4000 to the ingress so the websocket survives idle gaps (4000 s = ALB max). Tests: N/A automated (LB annotation). Manual: deploy, open ComfyUI, leave it idle >60 s, confirm no reconnect cycling; run a generation and confirm live progress holds. No UI code change → no screenshots.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
