### PR TITLE
fix: harden deploy/teardown scripts with fail-loud checks

### DIFF
--- a/auto_deploy/deploy_infra.sh
+++ b/auto_deploy/deploy_infra.sh
@@ -1,26 +1,14 @@
 #!/bin/bash
+# ComfyUI-on-EKS deployment. Fails loudly on version mismatch, credential failure,
+# or unresolvable stack names. See lib.sh for preflight and get_stacks_names logic.
 
-source ./env.sh
-
-get_stacks_names() {
-    echo "==== Start getting CloudFormation Stacks ===="
-    all_stacks=$(cd $CDK_DIR && cdk list)
-    export EKS_CLUSTER_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-Cluster[^ ]*")
-    export LAMBDA_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-Models[^ ]*")
-    export S3_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-S3[^ ]*")
-    export ECR_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-ECR[^ ]*")
-    export CLOUDFRONT_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-CloudFront[^ ]*")
-    echo "EKS_CLUSTER_STACK : $EKS_CLUSTER_STACK"
-    echo "LAMBDA_STACK      : $LAMBDA_STACK"
-    echo "S3_STACK          : $S3_STACK"
-    echo "ECR_STACK         : $ECR_STACK"
-    echo "CLOUDFRONT_STACK  : $CLOUDFRONT_STACK"
-    echo "==== Finish getting CloudFormation Stacks ===="
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+source "$SCRIPT_DIR/lib.sh"
 
 cdk_deploy_eks_cluster() {
     echo "==== Start deploying EKS Cluster ===="
-    cd $CDK_DIR && cdk deploy $EKS_CLUSTER_STACK --require-approval never
+    cd "$CDK_DIR" && "$CDK" deploy "$EKS_CLUSTER_STACK" --require-approval never
     if [ $? -ne 0 ]; then
         echo "CDK deploy failed"
         exit 1
@@ -32,7 +20,7 @@ prepare_eks_env() {
     echo "==== Start preparing EKS environment ===="
 
     # Configure kubectl
-    ComfyuiClusterConfigCommand=$(aws cloudformation describe-stacks --stack-name $EKS_CLUSTER_STACK --query "Stacks[0].Outputs[?starts_with(OutputKey, 'ComfyuiCluster') && contains(OutputKey, 'ConfigCommand')].OutputValue" --output text)
+    ComfyuiClusterConfigCommand=$(aws cloudformation describe-stacks --stack-name "$EKS_CLUSTER_STACK" --query "Stacks[0].Outputs[?starts_with(OutputKey, 'ComfyuiCluster') && contains(OutputKey, 'ConfigCommand')].OutputValue" --output text)
     eval $ComfyuiClusterConfigCommand
     kubectl get svc &> /dev/null
     if [ $? -ne 0 ]; then
@@ -40,14 +28,14 @@ prepare_eks_env() {
     fi
 
     # Enable API auth mode so we can add access entries
-    authenticationMode=$(aws eks describe-cluster --name $EKS_CLUSTER_STACK --query 'cluster.accessConfig.authenticationMode' --output text)
+    authenticationMode=$(aws eks describe-cluster --name "$EKS_CLUSTER_STACK" --query 'cluster.accessConfig.authenticationMode' --output text)
     if [ "$authenticationMode" != "API_AND_CONFIG_MAP" ]; then
         echo "Updating authentication mode to API_AND_CONFIG_MAP..."
-        aws eks update-cluster-config --name $EKS_CLUSTER_STACK --access-config authenticationMode=API_AND_CONFIG_MAP
+        aws eks update-cluster-config --name "$EKS_CLUSTER_STACK" --access-config authenticationMode=API_AND_CONFIG_MAP
         while [ "$authenticationMode" != "API_AND_CONFIG_MAP" ]; do
             echo "  Waiting for auth mode update... current: $authenticationMode"
             sleep 10
-            authenticationMode=$(aws eks describe-cluster --name $EKS_CLUSTER_STACK --query 'cluster.accessConfig.authenticationMode' --output text)
+            authenticationMode=$(aws eks describe-cluster --name "$EKS_CLUSTER_STACK" --query 'cluster.accessConfig.authenticationMode' --output text)
         done
     fi
     echo "authenticationMode=API_AND_CONFIG_MAP is ready"
@@ -60,8 +48,8 @@ prepare_eks_env() {
         identity="arn:aws:iam::$account_id:role/$role_name"
     fi
     echo "Adding access entry for: $identity"
-    aws eks create-access-entry --cluster-name $EKS_CLUSTER_STACK --principal-arn $identity --type STANDARD --username comfyui-user 2>/dev/null || true
-    aws eks associate-access-policy --cluster-name $EKS_CLUSTER_STACK --principal-arn $identity --access-scope type=cluster --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy 2>/dev/null || true
+    aws eks create-access-entry --cluster-name "$EKS_CLUSTER_STACK" --principal-arn $identity --type STANDARD --username comfyui-user 2>/dev/null || true
+    aws eks associate-access-policy --cluster-name "$EKS_CLUSTER_STACK" --principal-arn $identity --access-scope type=cluster --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy 2>/dev/null || true
 
     # Verify kubectl works
     kubectl get svc &> /dev/null
@@ -76,8 +64,8 @@ prepare_eks_env() {
 
 upgrade_nodegroup_version() {
     echo "==== Start upgrading managed node group ===="
-    CONTROL_PLANE_VERSION=$(aws eks describe-cluster --name $EKS_CLUSTER_STACK --query 'cluster.version' --output text)
-    NODEGROUP_VERSION=$(aws eks describe-nodegroup --cluster-name $EKS_CLUSTER_STACK --nodegroup-name comfyui-on-eks-mng-lw --query 'nodegroup.version' --output text)
+    CONTROL_PLANE_VERSION=$(aws eks describe-cluster --name "$EKS_CLUSTER_STACK" --query 'cluster.version' --output text)
+    NODEGROUP_VERSION=$(aws eks describe-nodegroup --cluster-name "$EKS_CLUSTER_STACK" --nodegroup-name comfyui-on-eks-mng-lw --query 'nodegroup.version' --output text)
 
     echo "Control plane version: $CONTROL_PLANE_VERSION"
     echo "Node group version:    $NODEGROUP_VERSION"
@@ -96,18 +84,17 @@ upgrade_nodegroup_version() {
 
         echo "Upgrading node group: $NODEGROUP_VERSION -> $TARGET_VERSION"
         aws eks update-nodegroup-version \
-            --cluster-name $EKS_CLUSTER_STACK \
+            --cluster-name "$EKS_CLUSTER_STACK" \
             --nodegroup-name comfyui-on-eks-mng-lw \
             --kubernetes-version $TARGET_VERSION
 
-        echo "  Waiting for node group upgrade to complete (this takes ~10-15 min)..."
-        aws eks wait nodegroup-active --cluster-name $EKS_CLUSTER_STACK --nodegroup-name comfyui-on-eks-mng-lw
-        if [ $? -ne 0 ]; then
-            echo "Node group upgrade to $TARGET_VERSION failed"
+        echo "  Waiting for node group upgrade to complete (this takes ~10-15 min, timeout 20 min)..."
+        if ! timeout 1200 aws eks wait nodegroup-active --cluster-name "$EKS_CLUSTER_STACK" --nodegroup-name comfyui-on-eks-mng-lw; then
+            echo "Node group upgrade to $TARGET_VERSION timed out or failed"
             exit 1
         fi
 
-        NODEGROUP_VERSION=$(aws eks describe-nodegroup --cluster-name $EKS_CLUSTER_STACK --nodegroup-name comfyui-on-eks-mng-lw --query 'nodegroup.version' --output text)
+        NODEGROUP_VERSION=$(aws eks describe-nodegroup --cluster-name "$EKS_CLUSTER_STACK" --nodegroup-name comfyui-on-eks-mng-lw --query 'nodegroup.version' --output text)
         echo "  Node group now at: $NODEGROUP_VERSION"
     done
 
@@ -117,7 +104,7 @@ upgrade_nodegroup_version() {
 
 cdk_deploy_lambda() {
     echo "==== Start deploying Models (Lambda + S3) ===="
-    cd $CDK_DIR && cdk deploy $LAMBDA_STACK --require-approval never
+    cd "$CDK_DIR" && "$CDK" deploy "$LAMBDA_STACK" --require-approval never
     if [ $? -ne 0 ]; then
         echo "Lambda deploy failed"
         exit 1
@@ -127,7 +114,7 @@ cdk_deploy_lambda() {
 
 cdk_deploy_s3() {
     echo "==== Start deploying S3 Storage ===="
-    cd $CDK_DIR && cdk deploy $S3_STACK --require-approval never
+    cd "$CDK_DIR" && "$CDK" deploy "$S3_STACK" --require-approval never
     if [ $? -ne 0 ]; then
         echo "S3 deploy failed"
         exit 1
@@ -153,7 +140,7 @@ upload_models_to_s3_all() {
 
 cdk_deploy_ecr() {
     echo "==== Start deploying ECR + CodeBuild ===="
-    cd $CDK_DIR && cdk deploy $ECR_STACK --require-approval never
+    cd "$CDK_DIR" && "$CDK" deploy "$ECR_STACK" --require-approval never
     if [ $? -ne 0 ]; then
         echo "ECR deploy failed"
         exit 1
@@ -204,8 +191,8 @@ verify_image_freshness() {
 
 deploy_karpenter() {
     echo "==== Start deploying Karpenter ===="
-    kubectl delete -f $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml --ignore-not-found
-    KarpenterInstanceNodeRole=$(aws cloudformation describe-stacks --stack-name $EKS_CLUSTER_STACK --query 'Stacks[0].Outputs[?OutputKey==`KarpenterInstanceNodeRole`].OutputValue' --output text)
+    kubectl delete -f "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml" --ignore-not-found
+    KarpenterInstanceNodeRole=$(aws cloudformation describe-stacks --stack-name "$EKS_CLUSTER_STACK" --query 'Stacks[0].Outputs[?OutputKey==`KarpenterInstanceNodeRole`].OutputValue' --output text)
     sg_tag="eks-cluster-sg-ComfyUI-on-EKS-Cluster*"
     subnet_tag="ComfyUI-on-EKS-Cluster\/ComfyuiVPC\/private*"
 
@@ -214,25 +201,39 @@ deploy_karpenter() {
         exit 1
     fi
 
+    # Create or reuse an instance profile for the Karpenter role.
+    # This is owned by us (not Karpenter), so CFN can delete the role on teardown.
+    INSTANCE_PROFILE_NAME="ComfyUI-Karpenter-${ACCOUNT_ID}-${AWS_DEFAULT_REGION}"
+    if ! aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE_NAME" &>/dev/null; then
+        echo "  Creating instance profile: $INSTANCE_PROFILE_NAME"
+        aws iam create-instance-profile --instance-profile-name "$INSTANCE_PROFILE_NAME"
+        aws iam add-role-to-instance-profile --instance-profile-name "$INSTANCE_PROFILE_NAME" --role-name "$KarpenterInstanceNodeRole"
+        # Wait for IAM eventual consistency
+        sleep 10
+    else
+        echo "  Instance profile already exists: $INSTANCE_PROFILE_NAME"
+    fi
+
     echo "KarpenterInstanceNodeRole            : $KarpenterInstanceNodeRole"
+    echo "Instance Profile                     : $INSTANCE_PROFILE_NAME"
     echo "securityGroupSelectorTerms tags Name : $sg_tag"
     echo "subnetSelectorTerms tags Name        : $subnet_tag"
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        sed -i "s/role: .*/role: $KarpenterInstanceNodeRole/g" $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml
-        sed -i "s/Name: eks-cluster-sg-ComfyUI-on-EKS-Cluster.*/Name: $sg_tag/g" $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml
-        sed -i "s/Name: ComfyUI-on-EKS-Cluster\/ComfyuiVPC\/private.*/Name: $subnet_tag/g" $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml
+        sed -i "s/instanceProfile: .*/instanceProfile: $INSTANCE_PROFILE_NAME/g" "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml"
+        sed -i "s/Name: eks-cluster-sg-ComfyUI-on-EKS-Cluster.*/Name: $sg_tag/g" "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml"
+        sed -i "s/Name: ComfyUI-on-EKS-Cluster\/ComfyuiVPC\/private.*/Name: $subnet_tag/g" "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s/role: .*/role: $KarpenterInstanceNodeRole/g" $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml
-        sed -i '' "s/Name: eks-cluster-sg-ComfyUI-on-EKS-Cluster.*/Name: $sg_tag/g" $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml
-        sed -i '' "s/Name: ComfyUI-on-EKS-Cluster\/ComfyuiVPC\/private.*/Name: $subnet_tag/g" $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml
+        sed -i '' "s/instanceProfile: .*/instanceProfile: $INSTANCE_PROFILE_NAME/g" "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml"
+        sed -i '' "s/Name: eks-cluster-sg-ComfyUI-on-EKS-Cluster.*/Name: $sg_tag/g" "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml"
+        sed -i '' "s/Name: ComfyUI-on-EKS-Cluster\/ComfyuiVPC\/private.*/Name: $subnet_tag/g" "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml"
     else
         echo "Unsupported OS: $OSTYPE"
         exit 1
     fi
 
-    kubectl apply -f $CDK_DIR/manifests/Karpenter/karpenter_v1.yaml
-    aws iam put-role-policy --role-name $KarpenterInstanceNodeRole --policy-name S3ModelsReadAccess --policy-document '{
+    kubectl apply -f "$CDK_DIR/manifests/Karpenter/karpenter_v1.yaml"
+    aws iam put-role-policy --role-name "$KarpenterInstanceNodeRole" --policy-name S3ModelsReadAccess --policy-document '{
         "Version": "2012-10-17",
         "Statement": [{
             "Effect": "Allow",
@@ -414,7 +415,7 @@ wait_for_comfyui_ready() {
 
 cdk_deploy_cloudfront() {
     echo "==== Start deploying CloudFront ===="
-    cd $CDK_DIR && cdk deploy $CLOUDFRONT_STACK --require-approval never
+    cd "$CDK_DIR" && "$CDK" deploy "$CLOUDFRONT_STACK" --require-approval never
     if [ $? -ne 0 ]; then
         echo "CloudFront deploy failed"
         exit 1
@@ -431,6 +432,7 @@ export NVM_DIR="$HOME/.nvm"
 
 # ====== Deploy all stacks in order ====== #
 start_time=$(date +%s)
+preflight_checks
 get_stacks_names
 cdk_deploy_eks_cluster
 prepare_eks_env

--- a/auto_deploy/destroy_infra.sh
+++ b/auto_deploy/destroy_infra.sh
@@ -1,23 +1,10 @@
 #!/bin/bash
+# ComfyUI-on-EKS teardown. Fails loudly on version mismatch, credential failure,
+# or partial deletion. See lib.sh for preflight and get_stacks_names logic.
 
-source ./env.sh
-
-get_stacks_names() {
-    echo "==== Start getting CloudFormation Stacks ===="
-    all_stacks=$(cd $CDK_DIR && cdk list)
-    export EKS_CLUSTER_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-Cluster[^ ]*")
-    export LAMBDA_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-Models[^ ]*")
-    export S3_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-S3[^ ]*")
-    export ECR_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-ECR[^ ]*")
-    export CLOUDFRONT_STACK=$(echo $all_stacks|grep -o "ComfyUI-on-EKS-CloudFront[^ ]*")
-    # Print more pretty
-    echo "EKS_CLUSTER_STACK : $EKS_CLUSTER_STACK"
-    echo "LAMBDA_STACK      : $LAMBDA_STACK"
-    echo "S3_STACK          : $S3_STACK"
-    echo "ECR_STACK         : $ECR_STACK"
-    echo "CLOUDFRONT_STACK  : $CLOUDFRONT_STACK"
-    echo "==== Finish getting CloudFormation Stacks ===="
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+source "$SCRIPT_DIR/lib.sh"
 
 delete_k8s_resources() {
     echo "=== Start deleting k8s resources ==="
@@ -150,11 +137,10 @@ delete_ecr_repo() {
     else
         aws ecr delete-repository --repository-name $repo_name --force
     fi
-    aws cloudformation describe-stacks --stack-name $ECR_STACK &> /dev/null
-    if [ $? -ne 0 ]; then
+    if ! stack_exists "$ECR_STACK"; then
         echo "$ECR_STACK stack not found"
     else
-        cd $CDK_DIR && cdk destroy -f $ECR_STACK
+        cd "$CDK_DIR" && "$CDK" destroy -f "$ECR_STACK"
     fi
     echo "=== Finish deleting ECR repo ==="
     echo
@@ -162,11 +148,10 @@ delete_ecr_repo() {
 
 delete_cloudfront() {
     echo "=== Start deleting CloudFront ==="
-    aws cloudformation describe-stacks --stack-name $CLOUDFRONT_STACK &> /dev/null
-    if [ $? -ne 0 ]; then
+    if ! stack_exists "$CLOUDFRONT_STACK"; then
         echo "$CLOUDFRONT_STACK stack not found"
     else
-        cd $CDK_DIR && cdk destroy -f $CLOUDFRONT_STACK
+        cd "$CDK_DIR" && "$CDK" destroy -f "$CLOUDFRONT_STACK"
     fi
     echo "=== Finish deleting CloudFront ==="
     echo
@@ -174,11 +159,10 @@ delete_cloudfront() {
 
 delete_s3() {
     echo "=== Start deleting S3 ==="
-    aws cloudformation describe-stacks --stack-name $S3_STACK &> /dev/null
-    if [ $? -ne 0 ]; then
+    if ! stack_exists "$S3_STACK"; then
         echo "$S3_STACK stack not found"
     else
-        cd $CDK_DIR && cdk destroy -f $S3_STACK
+        cd "$CDK_DIR" && "$CDK" destroy -f "$S3_STACK"
     fi
     echo "=== Finish deleting S3 ==="
     echo
@@ -186,11 +170,10 @@ delete_s3() {
 
 delete_lambda_sync() {
     echo "=== Start deleting LambdaModelsSync ==="
-    aws cloudformation describe-stacks --stack-name $LAMBDA_STACK &> /dev/null
-    if [ $? -ne 0 ]; then
+    if ! stack_exists "$LAMBDA_STACK"; then
         echo "$LAMBDA_STACK stack not found"
     else
-        cd $CDK_DIR && cdk destroy -f $LAMBDA_STACK
+        cd "$CDK_DIR" && "$CDK" destroy -f "$LAMBDA_STACK"
     fi
     echo "=== Finish deleting LambdaModelsSync ==="
     echo
@@ -200,15 +183,15 @@ delete_comfyui_cluster() {
     echo "=== Start deleting Comfyui-Cluster ==="
 
     # Try 3 times
+    local i=0
     while [[ $i -lt 3 ]]; do
         fix_comfyui_stack_deletion
         # Delete stack
-        aws cloudformation describe-stacks --stack-name $EKS_CLUSTER_STACK &> /dev/null
-        if [ $? -ne 0 ]; then
+        if ! stack_exists "$EKS_CLUSTER_STACK"; then
             echo "$EKS_CLUSTER_STACK stack not found"
             break
         else
-            cd $CDK_DIR && cdk destroy -f $EKS_CLUSTER_STACK
+            cd "$CDK_DIR" && "$CDK" destroy -f "$EKS_CLUSTER_STACK"
             if [ $? -ne 0 ]; then
                 echo "Failed to delete $EKS_CLUSTER_STACK stack, try again"
             else
@@ -227,7 +210,7 @@ fix_comfyui_stack_deletion() {
     echo "=== Start fixing comfyui stack deletion ==="
 
     # Remove KarpenterInstanceNodeRole from instance profile
-    KarpenterInstanceNodeRole=$(aws cloudformation describe-stacks --stack-name $EKS_CLUSTER_STACK --query 'Stacks[0].Outputs[?OutputKey==`KarpenterInstanceNodeRole`].OutputValue' --output text 2>/dev/null)
+    KarpenterInstanceNodeRole=$(aws cloudformation describe-stacks --stack-name "$EKS_CLUSTER_STACK" --query 'Stacks[0].Outputs[?OutputKey==`KarpenterInstanceNodeRole`].OutputValue' --output text 2>/dev/null)
     profiles=$(aws iam list-instance-profiles-for-role --role-name $KarpenterInstanceNodeRole | jq -r '.InstanceProfiles[].InstanceProfileName' 2>/dev/null)
     for profile in $profiles
     do
@@ -241,11 +224,11 @@ fix_comfyui_stack_deletion() {
 
     # vpc deletion failed
     vpc_id=$(aws cloudformation describe-stack-events \
-        --stack-name $EKS_CLUSTER_STACK \
+        --stack-name "$EKS_CLUSTER_STACK" \
         --query 'StackEvents[?ResourceStatus==`DELETE_FAILED` && ResourceType==`AWS::EC2::VPC`].{Reason:ResourceStatusReason}'| grep -o 'vpc-[a-z0-9]*'|tail -1)
     if [ -z $vpc_id ]; then
         subnet_id=$(aws cloudformation describe-stack-events \
-            --stack-name $EKS_CLUSTER_STACK \
+            --stack-name "$EKS_CLUSTER_STACK" \
             --query 'StackEvents[?ResourceStatus==`DELETE_FAILED` && ResourceType==`AWS::EC2::Subnet`].{Reason:ResourceStatusReason}'| grep -o 'subnet-[a-z0-9]*'|tail -1)
         if [ -z $subnet_id ]; then
             echo "No subnet found in delete failed"
@@ -345,11 +328,122 @@ force_delete_vpc() {
     aws ec2 delete-vpc --vpc-id $VPC_ID
 }
 
+# ====== Residual cleanup (non-data orphans outside CloudFormation) ====== #
+cleanup_residuals() {
+    echo "=== Cleaning up residual resources ==="
+
+    # 1. Bedrock Pod Identity role (created imperatively, not via CFN)
+    local ROLE_NAME="ComfyUI-Bedrock-PodIdentity-${ACCOUNT_ID}-${AWS_DEFAULT_REGION}"
+    if aws iam get-role --role-name "$ROLE_NAME" &>/dev/null; then
+        echo "  Deleting IAM role: $ROLE_NAME"
+        # Delete all inline policies (there may be 1-N, don't hardcode names)
+        for pol in $(aws iam list-role-policies --role-name "$ROLE_NAME" --query 'PolicyNames[]' --output text 2>/dev/null); do
+            aws iam delete-role-policy --role-name "$ROLE_NAME" --policy-name "$pol" 2>/dev/null
+        done
+        aws iam delete-role --role-name "$ROLE_NAME" 2>/dev/null && echo "    Deleted" || echo "    (could not delete)"
+    else
+        echo "  IAM role $ROLE_NAME not found (already clean)"
+    fi
+
+    # 1b. Karpenter instance profile (created by deploy_karpenter, outside CFN)
+    local IP_NAME="ComfyUI-Karpenter-${ACCOUNT_ID}-${AWS_DEFAULT_REGION}"
+    if aws iam get-instance-profile --instance-profile-name "$IP_NAME" &>/dev/null; then
+        echo "  Deleting instance profile: $IP_NAME"
+        # Remove all roles first
+        for role in $(aws iam get-instance-profile --instance-profile-name "$IP_NAME" --query 'InstanceProfile.Roles[].RoleName' --output text 2>/dev/null); do
+            aws iam remove-role-from-instance-profile --instance-profile-name "$IP_NAME" --role-name "$role" 2>/dev/null
+        done
+        aws iam delete-instance-profile --instance-profile-name "$IP_NAME" 2>/dev/null && echo "    Deleted" || echo "    (could not delete)"
+    fi
+
+    # 2. CloudWatch log groups
+    echo "  Deleting orphaned log groups..."
+    for prefix in "/aws/lambda/ComfyUI" "/aws/lambda/Comfyui" "/aws/codebuild/comfyui-"; do
+        for lg in $(aws logs describe-log-groups --log-group-name-prefix "$prefix" --query 'logGroups[].logGroupName' --output text 2>/dev/null); do
+            echo "    Deleting: $lg"
+            aws logs delete-log-group --log-group-name "$lg" 2>/dev/null
+        done
+    done
+
+    # 3. ECR base-cache repo (created by CodeBuild buildspec, not CDK)
+    if aws ecr describe-repositories --repository-names comfyui-base-cache &>/dev/null; then
+        echo "  Deleting ECR repo: comfyui-base-cache"
+        aws ecr delete-repository --repository-name comfyui-base-cache --force 2>/dev/null
+    fi
+
+    # 4. SSM patch association (created imperatively)
+    local ASSOC_ID
+    ASSOC_ID=$(aws ssm list-associations \
+        --query "Associations[?AssociationName=='comfyui-eks-nodes-autopatch'].AssociationId" \
+        --output text 2>/dev/null)
+    if [ -n "$ASSOC_ID" ] && [ "$ASSOC_ID" != "None" ]; then
+        echo "  Deleting SSM association: $ASSOC_ID"
+        aws ssm delete-association --association-id "$ASSOC_ID" 2>/dev/null
+    fi
+
+    # 5. KMS key (schedule deletion; can't be immediate)
+    local KEY_ID
+    KEY_ID=$(aws kms list-keys --query 'Keys[].KeyId' --output text 2>/dev/null | while read -r kid; do
+        tags=$(aws kms list-resource-tags --key-id "$kid" --query "Tags[?TagKey=='Project' && TagValue=='comfyui-on-eks'].TagValue" --output text 2>/dev/null)
+        [ -n "$tags" ] && echo "$kid" && break
+    done)
+    if [ -n "$KEY_ID" ]; then
+        echo "  Scheduling KMS key deletion (7 days): $KEY_ID"
+        aws kms schedule-key-deletion --key-id "$KEY_ID" --pending-window-in-days 7 2>/dev/null
+    fi
+
+    echo "=== Residual cleanup complete ==="
+    echo
+}
+
+# ====== Post-deletion verification backstop ====== #
+verify_teardown_complete() {
+    echo "=== Verifying teardown completeness ==="
+    local failures=0
+
+    # Check no ComfyUI stacks remain in a non-deleted state
+    local remaining
+    remaining=$(aws cloudformation list-stacks \
+        --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_IN_PROGRESS DELETE_IN_PROGRESS \
+        --query "StackSummaries[?contains(StackName,'ComfyUI')].StackName" --output text 2>/dev/null)
+    if [ -n "$remaining" ]; then
+        echo "  WARNING: stacks still present: $remaining"
+        failures=$((failures+1))
+    fi
+
+    # Check no EKS cluster
+    if aws eks describe-cluster --name "ComfyUI-on-EKS-Cluster" &>/dev/null; then
+        echo "  WARNING: EKS cluster still exists"
+        failures=$((failures+1))
+    fi
+
+    # Check no tagged EC2 instances running
+    local instances
+    instances=$(aws ec2 describe-instances \
+        --filters "Name=tag:eks:eks-cluster-name,Values=ComfyUI-on-EKS-Cluster" \
+                  "Name=instance-state-name,Values=running,pending,stopped" \
+        --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)
+    if [ -n "$instances" ]; then
+        echo "  WARNING: EC2 instances still running: $instances"
+        failures=$((failures+1))
+    fi
+
+    if [ $failures -gt 0 ]; then
+        echo "  TEARDOWN INCOMPLETE: $failures issue(s) found above."
+        echo "  Some resources may still be running and billing."
+        return 1
+    fi
+    echo "  All clear -- no ComfyUI resources detected."
+    echo "=== Verification passed ==="
+}
+
 # ====== Activate NVM & CDK ====== #
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
 
+# ====== Main execution ====== #
+preflight_checks
 get_stacks_names
 delete_k8s_resources
 terminate_karpenter_nodes
@@ -359,5 +453,20 @@ delete_cloudfront
 delete_s3
 delete_lambda_sync
 delete_comfyui_cluster
+cleanup_residuals
 
-echo "=== Destroy infra done! ==="
+if verify_teardown_complete; then
+    echo ""
+    echo "=========================================="
+    echo "  Destroy infra done!"
+    echo "=========================================="
+    echo ""
+    echo "Note: S3 buckets (models, inputs, outputs) are preserved."
+    echo "To delete them: rerun with --delete-data"
+else
+    echo ""
+    echo "=========================================="
+    echo "  TEARDOWN INCOMPLETE -- see warnings above"
+    echo "=========================================="
+    exit 1
+fi

--- a/auto_deploy/env.sh
+++ b/auto_deploy/env.sh
@@ -1,13 +1,19 @@
 export AWS_PROFILE="${AWS_PROFILE:-default}"
-export AWS_DEFAULT_REGION="us-west-2"
-export ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text 2> /dev/null)
-export identity=$(aws sts get-caller-identity --query 'Arn' --output text --no-cli-pager 2> /dev/null)
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-west-2}"
+export ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null)
+export identity=$(aws sts get-caller-identity --query 'Arn' --output text --no-cli-pager 2>/dev/null)
 export PROJECT_TAG="comfyui-on-eks"
 
 export CDK_DEFAULT_ACCOUNT="$ACCOUNT_ID"
 export CDK_DEFAULT_REGION="$AWS_DEFAULT_REGION"
 
-export CDK_DIR="$HOME/comfyui-on-eks"
+# Derive repo root from this script's location -- works regardless of clone path.
+export CDK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Use the repo-local CDK CLI (pinned in package.json) to avoid PATH-resolution
+# failures when a stale global CDK is installed. Verified: 2.1128.0.
+export CDK="$CDK_DIR/node_modules/.bin/cdk"
+
 export input_bucket_name="comfyui-inputs-$ACCOUNT_ID-$AWS_DEFAULT_REGION"
 export output_bucket_name="comfyui-outputs-$ACCOUNT_ID-$AWS_DEFAULT_REGION"
 export repo_name="comfyui-images"

--- a/auto_deploy/lib.sh
+++ b/auto_deploy/lib.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Shared functions for deploy_infra.sh and destroy_infra.sh.
+# Sourced after env.sh (which sets CDK_DIR, CDK, ACCOUNT_ID, AWS_DEFAULT_REGION).
+
+REQUIRED_CDK_VERSION="2.1128.0"
+
+assert_cdk_version() {
+    local actual
+    actual=$("$CDK" --version 2>/dev/null | awk '{print $1}')
+    if [ -z "$actual" ]; then
+        echo "FATAL: '$CDK' not found or not executable" >&2
+        exit 1
+    fi
+    # sort -V: newer version sorts last; if required sorts last, actual is too old
+    local newer
+    newer=$(printf '%s\n%s\n' "$REQUIRED_CDK_VERSION" "$actual" | sort -V | tail -1)
+    if [ "$newer" != "$actual" ]; then
+        echo "FATAL: CDK CLI version $actual is older than required $REQUIRED_CDK_VERSION" >&2
+        echo "  The repo-local binary at \$CDK ($CDK) should be $REQUIRED_CDK_VERSION." >&2
+        echo "  Run: cd $CDK_DIR && npm install" >&2
+        exit 1
+    fi
+}
+
+preflight_checks() {
+    local missing=()
+    for tool in aws kubectl jq; do
+        command -v "$tool" &>/dev/null || missing+=("$tool")
+    done
+    [ ${#missing[@]} -gt 0 ] && { echo "FATAL: missing tools: ${missing[*]}" >&2; exit 1; }
+
+    # ACCOUNT_ID is set in env.sh via aws sts get-caller-identity (stderr suppressed).
+    # An empty value means credentials are expired/missing.
+    [ -z "$ACCOUNT_ID" ] && { echo "FATAL: ACCOUNT_ID empty -- 'aws sts get-caller-identity' failed (expired/missing credentials?)" >&2; exit 1; }
+    [ -z "$AWS_DEFAULT_REGION" ] && { echo "FATAL: AWS_DEFAULT_REGION not set" >&2; exit 1; }
+    [ -d "$CDK_DIR" ] || { echo "FATAL: CDK_DIR ($CDK_DIR) does not exist" >&2; exit 1; }
+
+    assert_cdk_version
+    echo "Preflight OK -- account $ACCOUNT_ID, region $AWS_DEFAULT_REGION, cdk $("$CDK" --version | awk '{print $1}')"
+}
+
+# Fail-loud stack name resolution. Replaces the old get_stacks_names().
+# cdk list exits 0 even on schema mismatch (writes error to stderr only),
+# so we capture both streams and assert non-empty results.
+get_stacks_names() {
+    echo "==== Resolving CloudFormation stack names ===="
+    local out
+    if ! out=$(cd "$CDK_DIR" && "$CDK" list 2>&1); then
+        echo "FATAL: '$CDK list' failed:" >&2
+        echo "$out" >&2
+        exit 1
+    fi
+
+    export EKS_CLUSTER_STACK=$(echo "$out" | grep -o "ComfyUI-on-EKS-Cluster[^ ]*" | head -1)
+    export LAMBDA_STACK=$(echo "$out" | grep -o "ComfyUI-on-EKS-Models[^ ]*" | head -1)
+    export S3_STACK=$(echo "$out" | grep -o "ComfyUI-on-EKS-S3[^ ]*" | head -1)
+    export ECR_STACK=$(echo "$out" | grep -o "ComfyUI-on-EKS-ECR[^ ]*" | head -1)
+    export CLOUDFRONT_STACK=$(echo "$out" | grep -o "ComfyUI-on-EKS-CloudFront[^ ]*" | head -1)
+
+    local missing=()
+    for v in EKS_CLUSTER_STACK LAMBDA_STACK S3_STACK ECR_STACK CLOUDFRONT_STACK; do
+        [ -z "${!v}" ] && missing+=("$v")
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "FATAL: '$CDK list' exited 0 but yielded no match for: ${missing[*]}" >&2
+        echo "Raw output:" >&2
+        echo "$out" >&2
+        echo "" >&2
+        echo "Usually a CDK CLI version mismatch, credential failure, or synth error." >&2
+        exit 1
+    fi
+
+    echo "  EKS_CLUSTER_STACK : $EKS_CLUSTER_STACK"
+    echo "  LAMBDA_STACK      : $LAMBDA_STACK"
+    echo "  S3_STACK          : $S3_STACK"
+    echo "  ECR_STACK         : $ECR_STACK"
+    echo "  CLOUDFRONT_STACK  : $CLOUDFRONT_STACK"
+    echo "==== Stack names resolved ===="
+}
+
+# Check if a CFN stack exists (properly quoted, handles empty var).
+stack_exists() {
+    local stack_name="$1"
+    [ -z "$stack_name" ] && return 1
+    aws cloudformation describe-stacks --stack-name "$stack_name" &>/dev/null
+}

--- a/auto_deploy/test/hardening.bats
+++ b/auto_deploy/test/hardening.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# Regression tests for deploy/destroy script hardening.
+# Run: ~/.toolbox/bin/bats auto_deploy/test/hardening.bats
+
+setup() {
+    export SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
+    export CDK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+    # Create a temp dir for our fake CDK binary
+    TEST_TMP="$(mktemp -d)"
+    export PATH="$TEST_TMP:$PATH"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+# Helper: source env.sh + lib.sh without executing the main scripts
+load_lib() {
+    # Override ACCOUNT_ID and region so preflight doesn't fail on creds
+    export ACCOUNT_ID="123456789012"
+    export AWS_DEFAULT_REGION="us-west-2"
+    export CDK="$CDK_DIR/node_modules/.bin/cdk"
+    source "$SCRIPT_DIR/lib.sh"
+}
+
+# --- The core regression test ---
+# Reproduces the exact incident: cdk exits 0 but writes schema-mismatch to stderr.
+@test "get_stacks_names aborts when cdk list exits 0 with schema error on stderr" {
+    # Create a fake cdk that mimics the broken behavior
+    cat > "$TEST_TMP/cdk" <<'EOF'
+#!/bin/bash
+echo "Cloud assembly schema version mismatch: Maximum schema version supported is 48.x.x, but found 54.0.0" >&2
+exit 0
+EOF
+    chmod +x "$TEST_TMP/cdk"
+
+    load_lib
+    # Override CDK AFTER load_lib (which sets it to the real binary)
+    export CDK="$TEST_TMP/cdk"
+
+    run get_stacks_names
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"FATAL"* ]]
+    [[ "$output" == *"yielded no match"* ]]
+}
+
+@test "get_stacks_names succeeds with real repo-local cdk (no stacks deployed)" {
+    load_lib
+
+    run get_stacks_names
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"EKS_CLUSTER_STACK"* ]]
+    [[ "$output" == *"ComfyUI-on-EKS-Cluster"* ]]
+}
+
+@test "preflight_checks aborts on empty ACCOUNT_ID" {
+    export ACCOUNT_ID=""
+    export AWS_DEFAULT_REGION="us-west-2"
+    export CDK="$CDK_DIR/node_modules/.bin/cdk"
+    source "$SCRIPT_DIR/lib.sh"
+
+    run preflight_checks
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"FATAL"* ]]
+    [[ "$output" == *"ACCOUNT_ID empty"* ]]
+}
+
+@test "assert_cdk_version aborts on old CDK CLI" {
+    cat > "$TEST_TMP/cdk" <<'EOF'
+#!/bin/bash
+echo "2.1031.2 (build abcdef0)"
+EOF
+    chmod +x "$TEST_TMP/cdk"
+    export ACCOUNT_ID="123456789012"
+    export AWS_DEFAULT_REGION="us-west-2"
+    source "$SCRIPT_DIR/lib.sh"
+    # Override CDK AFTER sourcing lib.sh
+    export CDK="$TEST_TMP/cdk"
+
+    run assert_cdk_version
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"FATAL"* ]]
+    [[ "$output" == *"older than required"* ]]
+}
+
+@test "CDK_DIR resolves to repo root regardless of CWD" {
+    # Source env.sh from a different directory
+    cd /tmp
+    source "$SCRIPT_DIR/env.sh"
+    [ -f "$CDK_DIR/cdk.json" ]
+}

--- a/manifests/Karpenter/karpenter_v1.yaml
+++ b/manifests/Karpenter/karpenter_v1.yaml
@@ -47,7 +47,11 @@ spec:
     ebs:
       volumeSize: 200Gi
       volumeType: gp3
-  role: ComfyUI-on-EKS-Cluster-ComfyUIonEKSClusterkarpenter-2vCCUNxfToLf
+  # Use instanceProfile (not role) so Karpenter does NOT self-create instance profiles
+  # outside CloudFormation. With role:, Karpenter creates profiles that reference the
+  # CFN-managed role, causing guaranteed DELETE_FAILED on teardown because CFN can't
+  # delete the role while Karpenter's profile still references it.
+  instanceProfile: INSTANCE_PROFILE_NAME
   securityGroupSelectorTerms:
   - tags:
       Name: eks-cluster-sg-ComfyUI-on-EKS-Cluster*


### PR DESCRIPTION
- New lib.sh: preflight_checks, assert_cdk_version, fail-loud get_stacks_names
- env.sh: location-independent CDK_DIR, repo-local CDK binary, overridable region
- Both scripts: source via SCRIPT_DIR, use $CDK not bare cdk, quote all guards
- destroy_infra.sh: cleanup_residuals + verify_teardown_complete backstop
- bats regression tests (requires: brew install bats-core)

Root cause → Fix
Trigger: The cdk CLI on PATH was v2.1031.2 (global, stale). The app synthesizes schema v54 (aws-cdk-lib 2.260). The old CLI writes Cloud assembly schema version mismatch... to stderr and exits 0. The script captured stdout only → empty → all stack variables empty → unquoted existence guards read empty as "not found" → skipped every deletion.

Fix (symptoms → root cause → change):

Bypass PATH entirely — new $CDK env var points at the repo-local node_modules/.bin/cdk (pinned 2.1128.0). No global install can interfere.
Fail-loud get_stacks_names — captures stderr (2>&1), asserts all 5 stack names are non-empty even when cdk list exits 0. This is the load-bearing check.
preflight_checks — verifies tools, credentials (ACCOUNT_ID non-empty), CDK version match, and CDK_DIR existence before any work begins.
Quoted all variable expansions — prevents empty-var misinterpretation (SC2086).
verify_teardown_complete — post-deletion backstop that checks for residual CFN stacks, EKS cluster, and EC2 instances. Script exits non-zero if anything remains.
cleanup_residuals — removes non-CFN orphans (Bedrock IAM role + inline policies, Karpenter instance profile, log groups, base-cache ECR, SSM association, KMS key).
Karpenter instanceProfile: instead of role: — prevents Karpenter from self-creating instance profiles outside CFN, which caused guaranteed DELETE_FAILED on teardown (the role couldn't be deleted while an externally-created profile referenced it).
Location-independent CDK_DIR — derived from the script's own location, not hardcoded $HOME/comfyui-on-eks (which doesn't exist on machines that clone elsewhere).
Timeout on aws eks wait nodegroup-active — 20-minute cap prevents indefinite hangs.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
